### PR TITLE
18750 improvements xls files

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ try {
 }
 ```
 
+If the destination Drive is a **Shared Drive** (Google Workspace Shared Drive), you **must** include:
+```js
+params: {
+  supportsAllDrives: "true"
+}
+
 ### Subscribes to file changes.
 
 ```javascript


### PR DESCRIPTION
Pull-request for issue #18750 created by @jsanchez-slingr 

## What it does?

It adds improvements to handle xls files,  XLS and XLSX files will be automatically converted by setting the Google Sheets MIME type, allowing the file to be exported later if needed.

## How to test it?

- Navigate to eventplanner app in idea2, delete the storage.
- Navigate to files and execute `Connect to drive` action
- Open the builder and execute this script, do not forget to replace `FOLDER_ID` with the folder id where you want to store the file uploaded

```js
let file = sys.data.findOne('files',{label: 'file_example_XLS_10.xls (8.7kB)'})
let fileUploaded = pkg.googledrive.api.upload(file.field('file').id(), "testCoky.xls", "<FOLDER_ID>");
const res = pkg.googledrive.api.get('/files/'+ fileUploaded.id +'/export', {
  params: { mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
  settings: {
    forceDownload: true,
    downloadSync: true,
    fileName: "exported.xlsx"
  }
});
let record = sys.data.createRecord('files');
record.field('file').val({
  id: res.fileId,
  name: res.fileName,
  contentType: res.contentType
});
sys.data.save(record);
```
Make sure the file uploaded to you drive don't have xls extension it should be a Google Sheet.
Navigate to files and open `exported.xlsx` it should contain the same data that has the file uploaded `file_example_XLS_10.xls `.